### PR TITLE
change body heigth + reset msg error on collapsables click

### DIFF
--- a/src/js/1_colapsables.js
+++ b/src/js/1_colapsables.js
@@ -52,12 +52,14 @@ function handleClickDesign() {
   openDesign();
   closeFill();
   closeShare();
+  msgShareError.innerHTML = '';
 }
 //Función handle listener elemento Form Fill
 function handleClickFill() {
   closeDesign();
   openFill();
   closeShare();
+  msgShareError.innerHTML = '';
 }
 //Función handle listener elemento Form Share
 function handleClickShare() {

--- a/src/scss/layout/_page.scss
+++ b/src/scss/layout/_page.scss
@@ -5,7 +5,7 @@
   justify-content: space-between;
 }
 .body__main {
-  height: 100vh;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   gap: 3rem;


### PR DESCRIPTION
Change "height" to "min-height" and ok-bye problems

Remove message of error: 'Faltan campos por rellenar' when user clicks on design form or fill form